### PR TITLE
Added auto populating list to select device from

### DIFF
--- a/Basic_CP_Gui.ui
+++ b/Basic_CP_Gui.ui
@@ -37,7 +37,7 @@
      </rect>
     </property>
    </widget>
-   <widget class="QLineEdit" name="deviceEntry">
+   <widget class="QComboBox" name="deviceEntry">
     <property name="geometry">
      <rect>
       <x>140</x>
@@ -45,12 +45,6 @@
       <width>131</width>
       <height>20</height>
      </rect>
-    </property>
-    <property name="text">
-     <string>CP001</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
     </property>
    </widget>
    <widget class="QLabel" name="deviceLabel">

--- a/CustomPeripheralGUI.py
+++ b/CustomPeripheralGUI.py
@@ -13,7 +13,7 @@ from PyQt5 import QtWidgets
 import sys
 import asyncio
 from qasync import QEventLoop
-import customperipheral as cplib
+import CustomPeripheral as cplib
 from bleak import BleakClient
 from bleak import discover
 
@@ -43,9 +43,11 @@ async def button_wait(win):
 
 async def find_device(win, cp):
     """Search for device after button press"""
-    await button_wait(win)  # Wait for button press
     win.display_status("Scanning...")
-    devices = await discover()  # Discover devices on BLE
+    devices = await discover(120)  # Discover devices on BLE, set timeout in accordance to advertising interval
+    win.update_deviceList(devices)
+    win.display_status("Ready")
+    await button_wait(win)  # Wait for button press
     cp.set_name(win.device_name) # Get device name from text input window in GUI
     device_found = cp.get_address(devices) #  Check if device in list
     return device_found

--- a/customperipheral.py
+++ b/customperipheral.py
@@ -116,11 +116,15 @@ class MainWindow(QtWidgets.QMainWindow):
         # fast update of all data
         for i, data in enumerate(plot_list):
             self.line_array[i].setData(data)
-
+    
+    def update_deviceList(self, devices):
+        for i, device in enumerate(devices):
+            self.deviceEntry.addItem(device.name)
+    
     def get_device(self):
         """Connect button press callback, retrieves device name from text box and sets flag"""
         self.connect_button = 1
-        self.device_name = self.deviceEntry.text()
+        self.device_name = self.deviceEntry.currentText()
 
     def button_ack(self):
         """Clear button press flag"""


### PR DESCRIPTION
Sometimes typing in the name of the device or figuring it out is a pain. Program now automatically populates list of nearby devices on startup. Note that you have to set the discovery timeout to the appropriate length depending on the device's advertising interval. Next step will be adding a button for the scan functionality.